### PR TITLE
Add env example and gitignore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Uber API credentials (placeholder)
+UBER_CLIENT_ID=your-client-id-here
+UBER_CLIENT_SECRET=your-client-secret-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore environment files containing secrets
+.env
+# Node dependencies (if Node used later)
+node_modules/
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder Uber API credentials
- add `.gitignore` to keep `.env` and other development files out of version control

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684467ceab58832d907ae49c6ac5b64d